### PR TITLE
Docs: Fix typos and inconsistencies

### DIFF
--- a/authenticator.php
+++ b/authenticator.php
@@ -2,10 +2,10 @@
 /**
  * Plugin Name: Authenticator
  * Plugin URI:  https://github.com/bueltge/Authenticator
- * Description: This plugin allows you to make your WordPress site accessible to logged in users only. In other words to view your site they have to create / have an account in your site and be logged in. No configuration necessary, simply activating - that's all.
+ * Description: This plugin allows you to make your WordPress site accessible to logged in users only. In other words, to view your site they have to create or have an account on your site and be logged in. No configuration necessary, simply activating - that's all.
  * Author:      Inpsyde GmbH
  * Version:     1.3.0
- * Author URI:  http://inpsyde.com/
+ * Author URI:  https://inpsyde.com/
  * License:     GPLv3+
  * License URI: ./assets/license.txt
  * Text Domain:  authenticator
@@ -395,7 +395,7 @@ class Authenticator {
 	public function authenticate_rest_api() {
 
 		if ( has_filter('rest_authentication_errors') && ! self::authenticate_user() ) {
-			
+
 			add_action( 'rest_authentication_errors', function() {
 
 				return new WP_Error(

--- a/inc/class-Authenticator_Settings.php
+++ b/inc/class-Authenticator_Settings.php
@@ -103,7 +103,7 @@ class Authenticator_Settings {
 
 		add_settings_field(
 			'disable_xmlrpc',
-			__( 'Disable XMLRPC Interface?', Authenticator::TEXTDOMAIN ),
+			__( 'Disable XML-RPC Interface?', Authenticator::TEXTDOMAIN ),
 			array( $this, 'checkbox' ),
 			$this->page,
 			$this->section,

--- a/readme.md
+++ b/readme.md
@@ -3,28 +3,29 @@
 This plugin allows you to make your WordPress site accessible to logged in users only.
 
 ## Description
-This plugin allows you to make your WordPress site accessible to logged in users only. In other words to view your site they have to create / have an account in your site and be logged in. No configuration necessary, simply activating - thats all.
+This plugin allows you to make your WordPress site accessible to logged in users only. In other words, to view your site they have to create or have an account on your site and be logged in. No configuration necessary, simply activating - that's all.
 
 ### Made by [Inpsyde](http://inpsyde.com) &middot; We love WordPress
 
 ## Installation
 ### Requirements
-* WordPress version 1.5 and later; current (08/2014) tested up to 4.0-RC1
-* PHP 5.2*
+* WordPress version 1.5 and later.
+* PHP 5.2 and later.
+* Single or Multisite installation.
 
 On PHP-CGI setups:
 
-* `mod_setenvif` or `mod_rewrite` (if you want to user HTTP-Authentication for feeds)
+- `mod_setenvif` or `mod_rewrite` (if you want to user HTTP authentication for feeds).
 
 ### Installation
-1. Unpack the download-package
+1. Unzip the downloaded package.
 2. Upload folder include the file to the `/wp-content/plugins/` directory.
-3. Activate the plugin through the `Plugins` menu in WordPress
+3. Activate the plugin through the `Plugins` menu in WordPress.
 
-or use the installer via backend of WordPress
+Or use the installer via the back end of WordPress.
 
 ### On PHP-CGI setups
-If you want to use HTTP-Authentication for feeds (available since 1.1.0 as a *optional* feature) you have to update your `.htaccess` file. If [mod_setenvif](http://httpd.apache.org/docs/2.0/mod/mod_setenvif.html) is available, add the following line to your `.htaccess`:
+If you want to use HTTP authentication for feeds (available since 1.1.0 as an *optional* feature) you have to update your `.htaccess` file. If [mod_setenvif](http://httpd.apache.org/docs/2.0/mod/mod_setenvif.html) is available, add the following line to your `.htaccess`:
 
 ```
 SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
@@ -36,7 +37,7 @@ Otherwise you need [mod_rewrite](http://httpd.apache.org/docs/current/mod/mod_re
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 ```
 
-In a typical Wordpress .htaccess it all looks like:
+In a typical WordPress `.htaccess` it all looks like:
 
 ```
 <IfModule mod_rewrite.c>
@@ -50,7 +51,7 @@ RewriteRule . /index.php [L]
 </IfModule>
 ```
 
-respectively in a multisite installation:
+On a multisite installation:
 
 ```
 # BEGIN WordPress
@@ -70,64 +71,68 @@ RewriteRule . index.php [L]
 # END WordPress
 ```
 ## Settings
-You can change the settings of Authenticator on Options → Reading. The settings refer to the behaviour of your blog's feeds. Should they be protected by HTTP-Authentication (not all Feed-Readers support this) or by an authentication token, which is simply add to your feed URL as Parameter. The third option is to keep everything in place. So Feed-URLs will be redirected to the login page if the user is not logged in (send no auth-cookie). 
+You can change the settings of Authenticator in Settings → Reading. The settings refer to the behavior of your blog's feeds. They can be protected by HTTP authentication (not all feed readers support this) or by an authentication token which is added to your feed URL as a parameter. The third option is to keep everything in place. So feed URLs will be redirected to the login page if the user is not logged in (send no auth-cookie).
 
-If you using token authentication, you can show the token to the blog users on their profile settings page by setting these option.
+If you using token authentication, you can show the token to the blog users on their profile settings page by setting this option.
 
 ### HTTP Auth
-Users can gain access to the feed with their Username/Password. 
+Users can gain access to the feed with their username and password.
 
 ### Token Auth
-The plugin will generate a token automaticaly, when choosing this option. Copy this token and share it with the people who should have access to your feed. If your token is `ef05aa961a0c10dce006284213727730` the feed-URLs looks like so:
-```php
-# main feed
-http://yourblog.com/feed/?ef05aa961a0c10dce006284213727730
+The plugin will generate a token automatically when choosing this option. Copy this token and share it with the people who should have access to your feed. If your token is `ef05aa961a0c10dce006284213727730` the feed URLs look like so:
 
-#main comment feed 
-http://yourblog.com/comments/feed/?ef05aa961a0c10dce006284213727730
+```
+# Main feed
+https://example.com/feed/?ef05aa961a0c10dce006284213727730
 
-#without permalinks
-http://yourblog.com/?feed=rss2&ef05aa961a0c10dce006284213727730
+# Main comment feed
+https://example.com/comments/feed/?ef05aa961a0c10dce006284213727730
+
+# Without permalinks
+https://example.com/?feed=rss2&ef05aa961a0c10dce006284213727730
 ```
 
 ## Screenshots
 1. Authenticator's setting options at Settings → Reading.
 ![Screenshot of setting options at Settings → Reading](https://raw2.github.com/bueltge/Authenticator/master/assets/screenshot-1.png)
 
-2. Auth-Token for feeds is displayed on the users profile settings page.
-![Screenshot of Auth-Token for feeds is displayed on the users profile settings page](https://raw2.github.com/bueltge/Authenticator/master/assets/screenshot-2.png)
+2. Auth token for feeds is displayed on the users profile settings page.
+![Screenshot of Auth token for feeds is displayed on the users profile settings page](https://raw2.github.com/bueltge/Authenticator/master/assets/screenshot-2.png)
 
 ## API
 ### Filters
-* `authenticator_get_options` Whith this filter you have access to the current authentication-token: 
-```php
-<?php
-$authenticator_options = apply_filters( 'authenticator_get_options', array() );
-```
-* `authenticator_bypass` gives you the posibillity to completly bypass the authentication. No authentication will be required then.
-```php
-<?php
-add_filter( 'authenticator_bypass', '__return_true' );
-```
-* `authenticator_bypass_feed_auth` gives you the posibillity to open the feeds for everyone. No authentication will be required then.
-```php
-<?php
-add_filter( 'authenticator_bypass_feed_auth', '__return_true' );
-```
+* `authenticator_get_options` gives you access to the current authentication token:
+
+    ```php
+    $authenticator_options = apply_filters( 'authenticator_get_options', array() );
+    ```
+
+* `authenticator_bypass` gives you the possibillity to completely bypass the authentication. No authentication will be required then.
+
+    ```php
+    add_filter( 'authenticator_bypass', '__return_true' );
+    ```
+
+* `authenticator_bypass_feed_auth` gives you the possibility to open the feeds for everyone. No authentication will be required then.
+
+    ```php
+    add_filter( 'authenticator_bypass_feed_auth', '__return_true' );
+    ```
+
 * `authenticator_exclude_pagenows` Pass an array of `$GLOBALS[ 'pagenow' ]` values to it, to exclude several WordPress pages from redirecting to the login page.
 
 * `authenticator_exclude_ajax_actions` AJAX-Actions (independend of `_nopriv`) which should not be authenticated (remain open for everyone)
 
 * `authenticator_exclude_posts` List of post-titles which should remain public, like the follow example source to public the 'Contact'-page.
-```php
-<?php
-add_action( 'plugins_loaded', function() {
-    add_filter( 'authenticator_exclude_posts', function( $titles ) {
-        $titles[] = 'Contact'; // here goes the post-title of the post/page you want to exclude
-        return $titles;
+
+    ```php
+    add_action( 'plugins_loaded', function() {
+        add_filter( 'authenticator_exclude_posts', function( $titles ) {
+            $titles[] = 'Contact'; // here goes the post-title of the post/page you want to exclude
+            return $titles;
+        } );
     } );
-} );
-```
+    ```
 
 ## Other Notes
 ### Bugs, technical hints or contribute
@@ -136,12 +141,11 @@ Please give me feedback, contribute and file technical bugs on [GitHub Repo](htt
 ### Authors, Contributors
 [Contributors Stats](https://github.com/bueltge/Authenticator/graphs/contributors)
 
-### Licence
+### License
 Good news, this plugin is free for everyone! Since it's released under the [GPL](./license.txt), you can use it free of charge on your personal or commercial blog.
 
 ### Translations
-The plugin comes with various translations, please refer to the [WordPress Codex](http://codex.wordpress.org/Installing_WordPress_in_Your_Language "Installing WordPress in Your Language") for more information about activating the translation. If you want to help to translate the plugin to your language, please have a look at the .po file which contains all defintions and may be used with a [gettext](http://www.gnu.org/software/gettext/) editor like [Poedit](http://www.poedit.net/) (Windows) or plugin for WordPress [Localization](http://wordpress.org/extend/plugins/codestyling-localization/).
+The plugin comes with various translations, please refer to the [WordPress Codex](https://codex.wordpress.org/Installing_WordPress_in_Your_Language) for more information about activating the translation. If you want to help to translate the plugin to your language, please have a look at the `.pot` file which contains all defintions and may be used with a [gettext](http://www.gnu.org/software/gettext/) editor like [Poedit](http://www.poedit.net/) (Windows) or plugin for WordPress [Localization](http://wordpress.org/extend/plugins/codestyling-localization/).
 
-
-## Changelog
+## Change Log
 See [commits](https://github.com/bueltge/Authenticator/commits/master) or read the short [version](https://wordpress.org/plugins/authenticator/#developers)

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 This plugin allows you to make your WordPress site accessible to logged in users only.
 
 == Description ==
-This plugin allows you to make your WordPress site accessible to logged in users only. In other words to view your site they have to create / have an account in your site and be logged in. No configuration necessary, simply activating - thats all.
+This plugin allows you to make your WordPress site accessible to logged in users only. In other words, to view your site they have to create or have an account on your site and be logged in. No configuration necessary, simply activating - that's all.
 
 = Crafted by Inpsyde =
 The team at [Inpsyde](http://inpsyde.com) is engineering the web and WordPress since 2006.
@@ -24,22 +24,22 @@ Please give me feedback, contribute and file technical bugs on [GitHub Repo](htt
 
 == Installation ==
 = Requirements =
-* WordPress version 1.5 and later, see tested up to
-* PHP 5.2*
-* Single or Multisite installation
+* WordPress version 1.5 and later.
+* PHP 5.2 or later.
+* Single or Multisite installation.
 
 On PHP-CGI setups:
- * `mod_setenvif` or `mod_rewrite` (if you want to user HTTP-Authentication for feeds)
+ - `mod_setenvif` or `mod_rewrite` (if you want to user HTTP authentication for feeds).
 
 = Installation =
-1. Unpack the download-package
+1. Unzip the downloaded package.
 2. Upload folder include the file to the `/wp-content/plugins/` directory.
-3. Activate the plugin through the `Plugins` menu in WordPress
+3. Activate the plugin through the `Plugins` menu in WordPress.
 
-or use the installer via backend of WordPress
+or use the installer via the back end of WordPress.
 
 = On PHP-CGI setups =
-If you want to use HTTP-Authentication for feeds (available since 1.1.0 as a *optional* feature) you have to update your `.htaccess` file. If [mod_setenvif](http://httpd.apache.org/docs/2.0/mod/mod_setenvif.html) is available, add the following line to your `.htaccess`:
+If you want to use HTTP authentication for feeds (available since 1.1.0 as an *optional* feature) you have to update your `.htaccess` file. If [mod_setenvif](http://httpd.apache.org/docs/2.0/mod/mod_setenvif.html) is available, add the following line to your `.htaccess`:
 
 	SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
 
@@ -47,8 +47,7 @@ Otherwise you need [mod_rewrite](http://httpd.apache.org/docs/current/mod/mod_re
 
 	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-In a typical Wordpress .htaccess it all looks like:
-
+In a typical WordPress `.htaccess` it all looks like:
 
 	<IfModule mod_rewrite.c>
 		RewriteEngine On
@@ -60,7 +59,7 @@ In a typical Wordpress .htaccess it all looks like:
 		RewriteRule . /index.php [L]
 	</IfModule>
 
-respectively in a multisite installation:
+On a multisite installation:
 
 	# BEGIN WordPress
 	RewriteEngine On
@@ -79,53 +78,49 @@ respectively in a multisite installation:
 	# END WordPress
 
 = Settings =
-You can change the settings of Authenticator on Options → Reading. The settings refer to the behaviour of your blog's feeds. Should they be protected by HTTP-Authentication (not all Feed-Readers support this) or by an authentication token, which is simply add to your feed URL as Parameter. The third option is to keep everything in place. So Feed-URLs will be redirected to the login page if the user is not logged in (send no auth-cookie).
+You can change the settings of Authenticator in Settings → Reading. The settings refer to the behavior of your blog's feeds. They can be protected by HTTP authentication (not all feed readers support this) or by an authentication token which is added to your feed URL as a parameter. The third option is to keep everything in place. So feed URLs will be redirected to the login page if the user is not logged in (send no auth-cookie).
 
-If you using token authentication, you can show the token to the blog users on their profile settings page by setting these option.
+If you using token authentication, you can show the token to the blog users on their profile settings page by setting this option.
 
 = HTTP Auth =
-Users can gain access to the feed with their Username/Password.
+Users can gain access to the feed with their username and password.
 
 = Token Auth =
-The plugin will generate a token automaticaly, when choosing this option. Copy this token and share it with the people who should have access to your feed. If your token is ```ef05aa961a0c10dce006284213727730``` the feed-URLs looks like so:
+The plugin will generate a token automatically when choosing this option. Copy this token and share it with the people who should have access to your feed. If your token is `ef05aa961a0c10dce006284213727730` the feed URLs look like so:
 
-	# main feed
-	http://yourblog.com/feed/?ef05aa961a0c10dce006284213727730
+	# Main feed
+	https://example.com/feed/?ef05aa961a0c10dce006284213727730
 
-	#main comment feed
-	http://yourblog.com/comments/feed/?ef05aa961a0c10dce006284213727730
+	# Main comment feed
+	https://example.com/comments/feed/?ef05aa961a0c10dce006284213727730
 
-	#without permalinks
-	http://yourblog.com/?feed=rss2&ef05aa961a0c10dce006284213727730
+	# Without permalinks
+	https://example.com/?feed=rss2&ef05aa961a0c10dce006284213727730
 
 = API =
 
 **Filters**
 
-* `authenticator_get_options` Whith this filter you have access to the current authentication-token:
+* `authenticator_get_options` gives you access to the current authentication token:
 
 	<?php
 	$authenticator_options = apply_filters( 'authenticator_get_options', array() );
 
-
-* `authenticator_bypass` gives you the posibillity to completly bypass the authentication. No authentication will be required then.
+* `authenticator_bypass` gives you the possibillity to completely bypass the authentication. No authentication will be required then.
 
 	<?php
 	add_filter( 'authenticator_bypass', '__return_true' );
 
-
-* `authenticator_bypass_feed_auth` gives you the posibillity to open the feeds for everyone. No authentication will be required then.
+* `authenticator_bypass_feed_auth` gives you the possibillity to open the feeds for everyone. No authentication will be required then.
 
 	<?php
 	add_filter( 'authenticator_bypass_feed_auth', '__return_true' );
-
 
 * `authenticator_exclude_pagenows` Pass an array of `$GLOBALS[ 'pagenow' ]` values to it, to exclude several WordPress pages from redirecting to the login page.
 
 * `authenticator_exclude_ajax_actions` AJAX-Actions (independend of `_nopriv`) which should not be authenticated (remain open for everyone)
 
 * `authenticator_exclude_posts` List of post-titles which should remain public, like the follow example source to public the 'Contact'-page.
-
 
 		<?php
 		add_action( 'plugins_loaded', function() {
@@ -135,17 +130,16 @@ The plugin will generate a token automaticaly, when choosing this option. Copy t
 			} );
 		} );
 
-
 == Screenshots ==
 1. Authenticator's setting options at Settings → Reading.
-2. Auth-Token for feeds is displayed on the users profile settings page.
+2. Auth token for feeds is displayed on the user's profile settings page.
 
 == Other Notes ==
-= Licence =
+= License =
 Good news, this plugin is free for everyone! Since it's released under the GPL, you can use it free of charge on your personal or commercial blog. But if you enjoy this plugin, you can thank me and leave a [small donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6069955) for the time I've spent writing and supporting this plugin. And I really don't want to know how many hours of my life this plugin has already eaten ;)
 
 = Translations =
-The plugin comes with various translations, please refer to the [WordPress Codex](http://codex.wordpress.org/Installing_WordPress_in_Your_Language "Installing WordPress in Your Language") for more information about activating the translation. If you want to help to translate the plugin to your language, please have a look at the translation possibility in [this page here](https://translate.wordpress.org/projects/wp-plugins/authenticator).
+The plugin comes with various translations, please refer to the [WordPress Codex](https://codex.wordpress.org/Installing_WordPress_in_Your_Language) for more information about activating the translation. If you want to help to translate the plugin to your language, please have a look at the translation possibility in [this page here](https://translate.wordpress.org/projects/wp-plugins/authenticator).
 
 = Donation? =
 You want to donate - we prefer a positive review, not more.
@@ -154,50 +148,50 @@ You want to donate - we prefer a positive review, not more.
 
 = 1.3.0 (2017-11-30) =
 * Fixed a topic on login of users if you exclude posts from the Authenticator.
-* Add new filter hook to bypass the plugin `authenticator_bypass`, see the readme
-* Should now ready for translations from the WordPress translation service.
+* Add new filter hook to bypass the plugin `authenticator_bypass`, see the readme.
+* Should now be ready for translations from the WordPress translation service.
 
 = 1.2.3 (08/10/2017) =
-* Fixed loop about settings that create an fatal error.
+* Fixed loop about settings that create a fatal error.
 * Added authentication also for REST API; probs steffenster.
 
 = 1.2.2 (08/10/2017) =
 * Update readme to solve support questions, it works also under newer WP versions, tested up 4.9-alpha.
 
 = 1.2.1 (08/31/2014) =
-* Add guard for the constant XMLRPC_REQUEST
-* Fix for XMLRPC bug [#17](https://github.com/bueltge/Authenticator/issues/17)
-* Enhance the readme to exclude posts/pages [#18](https://github.com/bueltge/Authenticator/issues/18)
+* Add guard for the constant `XMLRPC_REQUEST`.
+* Fix for XML-RPC bug [#17](https://github.com/bueltge/Authenticator/issues/17).
+* Enhance the readme to exclude posts/pages [#18](https://github.com/bueltge/Authenticator/issues/18).
 
 = 1.2.0 (06/26/2014) =
-* Fix the php notice [#15](https://github.com/bueltge/Authenticator/issues/15)
-* Fix [#14][https://github.com/bueltge/Authenticator/issues/14]
-* Add a removel of backlink in login footer [#8](https://github.com/bueltge/Authenticator/issues/8)
-* Filter for Ajax actions [#12](https://github.com/bueltge/Authenticator/issues/12)
-* Redefine `$reauth` for redirect [#11](https://github.com/bueltge/Authenticator/issues/11)
-* Apply API Hook for exclude several URLs from redirect [#10](https://github.com/bueltge/Authenticator/issues/10)
-* Add settings for XMLRPC [#9](https://github.com/bueltge/Authenticator/issues/9)
-* Add Composer possibility
-* Update readme to see all information on wp.org Repo
+* Fix the PHP notice [#15](https://github.com/bueltge/Authenticator/issues/15).
+* Fix [#14](https://github.com/bueltge/Authenticator/issues/14).
+* Add a removal of backlink in login footer [#8](https://github.com/bueltge/Authenticator/issues/8).
+* Filter for Ajax actions [#12](https://github.com/bueltge/Authenticator/issues/12).
+* Redefine `$reauth` for redirect [#11](https://github.com/bueltge/Authenticator/issues/11).
+* Apply API Hook for exclude several URLs from redirect [#10](https://github.com/bueltge/Authenticator/issues/10).
+* Add settings for XML-RPC [#9](https://github.com/bueltge/Authenticator/issues/9).
+* Add Composer support.
+* Update readme to see all information on wordpress.org Repo.
 
 = 1.1.0 (04/17/2014) =
-* add http authentification for feeds
-* add settings for reading feed
-* add token auth for feeds
+* Add HTTP authentification for feeds.
+* Add settings for reading feed.
+* Add token auth for feeds.
 
 = 1.0.0 (01/20/2012) =
-* fix in MU for redirect, also if the user have not an account
-* small rewrite for better codex
+* Fix in MU for redirect, also if the user have not an account.
+* Small rewrite for better codex.
 
 = v0.4.1 (04/20/2011) =
-* Remove network comment for use different in blogs of WPMultisite
+* Remove network comment for use different in blogs of WPMultisite.
 
 = v0.4.0 (04/11/2011) =
-* Bugfix for login without multisite
-* ask for multisite
-* Fix for use plugin WP smaller 3.*
-* Also usable in mu-plugins folder
+* Bugfix for login without multisite.
+* Ask for multisite.
+* Fix for use plugin WP smaller 3.*.
+* Also usable in mu-plugins folder.
 
 =  v0.3.0 (04/06/2011) =
-* Add check for rights to publish posts to use the plugin on Multisite Install; only users with this rights have acces to the blog of Mutlisite install
-* Small changes on code
+* Add check for rights to publish posts to use the plugin on Multisite Install; only users with this rights have acces to the blog of Mutlisite install.
+* Small changes on code.


### PR DESCRIPTION
Some typos, some using en_GB spellings instead of en_US, just generally cleaner that makes it easier to read.